### PR TITLE
add absolute output path to webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
 		'dist/www/app': './ClientApp/Client.ts'
 	},
 	output: {
-		path: './',
+		path: __dirname + '/',
 		filename: '[name].js'
 	},
 	resolve: {


### PR DESCRIPTION
Fixed the following issue on Mac and Windows:

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./" is not an absolute path!
```