### PR TITLE
Upgrade version of depencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
 	},
 	"devDependencies": {
 		"@types/knuddels-userapps-api": "^1.0.0",
-		"ts-loader": "^2.0.0",
-		"typescript": "^2.2.1",
-		"webpack": "^2.2.1"
+		"ts-loader": "^4.4.2",
+		"typescript": "^3.0.1",
+		"webpack": "^4.16.5",
+		"webpack-cli": "^3.1.0"
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	mode: 'production',
 	entry: {
 		'dist/main' : './ServerApp/Server.ts',
 		'dist/www/app': './ClientApp/Client.ts'
@@ -11,7 +12,7 @@ module.exports = {
 		extensions: [".ts"]
 	},
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /\.(ts)$/,
 				exclude: /node_modules/,


### PR DESCRIPTION
I've got updated some required dependencies. `webpack` require with newer versions the` CLI` package - With the new `webpack` version, a changed configuration of the` modules`-part is given, the `webpack.config.js` was here changed for the new `API`.

In addition, I added a `.gitignore` to exclude non-relevant files and folders.